### PR TITLE
allow passing of separate location for facility

### DIFF
--- a/models/types.ts
+++ b/models/types.ts
@@ -17,6 +17,8 @@ import OSRM from 'osrm';
 import { LCAresults } from './lcaModels';
 
 export interface RequestParams {
+  facilityLat: number;
+  facilityLng: number;
   lat: number;
   lng: number;
   system: string;


### PR DESCRIPTION
optionally pass a separate facility location.  This should only affect a few things -- moveIn trip results and per-cluster transportation cost info.