### PR TITLE
convert biomass target in metric tons to short tons

### DIFF
--- a/processYear.ts
+++ b/processYear.ts
@@ -94,6 +94,8 @@ export const processClustersForYear = async (
         totalTransportationDistance: 0,
       };
 
+      const TONNE_TO_TON = 1.10231; // 1 metric ton = 1.10231 short tons
+      biomassTarget = biomassTarget * TONNE_TO_TON;
       while (results.totalFeedstock < biomassTarget) {
         if (
           results.radius > 40000 &&
@@ -209,7 +211,7 @@ export const processClustersForYear = async (
       const lca = await runLca(lcaInputs);
       // console.log(lca);
       results.lcaResults = lca;
-      // $ / wet metric ton
+      // $ / wet short ton
       const fuelCost =
         (results.totalFeedstockCost + results.totalTransportationCost + results.totalMoveInCost) /
         results.totalFeedstock;
@@ -218,7 +220,7 @@ export const processClustersForYear = async (
 
       const moistureContentPercentage = params.moistureContent / 100.0;
 
-      // calculate dry values ($ / dry metric ton)
+      // calculate dry values ($ / dry short ton)
       results.totalDryFeedstock = results.totalFeedstock * (1 - moistureContentPercentage);
       results.totalDryCoproduct = results.totalCoproduct * (1 - moistureContentPercentage);
 


### PR DESCRIPTION
FRCS outputs weight in short tons, thus the total feedstock is in short tons. We are comparing total feedstock in short tons with biomass target in metric tons. Biomass target should come from the TEA model. 