### PR TITLE
update transportation model: make payload another input of the model

### DIFF
--- a/transportation.ts
+++ b/transportation.ts
@@ -7,9 +7,47 @@ const TRUCK_LABOR = 22.66;
 const DRIVERS_PER_TRUCK = 1.67;
 const MILES_PER_GALLON = 6;
 const OIL_ETC_COST = 0.35; // $/mile
-const KM_TO_MILES = 0.621371;
+export const KM_TO_MILES = 0.621371;
+export const FULL_TRUCK_PAYLOAD = 25; // FRCS assumption (in green tons)
 
-export const getTransportationCost = (distance: number, duration: number, fuelCost: number, payload: number) => {
+export const getTransportationCostTotal = (
+  feedstockAmount: number,
+  distance: number,
+  duration: number,
+  dieselFuelPrice: number,
+) => {
+  let transportationCostFullPayloadPerGT = 0;
+  if (feedstockAmount >= FULL_TRUCK_PAYLOAD) {
+    transportationCostFullPayloadPerGT = getTransportationCostPerGT(
+      distance,
+      duration,
+      dieselFuelPrice,
+      FULL_TRUCK_PAYLOAD
+    );
+  }
+  let transportationCostPartialPayloadPerGT = 0;
+  const partialPayload = feedstockAmount % FULL_TRUCK_PAYLOAD;
+  if (partialPayload > 0) {
+    transportationCostPartialPayloadPerGT = getTransportationCostPerGT(
+      distance,
+      duration,
+      dieselFuelPrice,
+      partialPayload
+    );
+  }
+  const transportationCostTotal =
+    (feedstockAmount - partialPayload) * transportationCostFullPayloadPerGT +
+    partialPayload * transportationCostPartialPayloadPerGT;
+
+  return transportationCostTotal;
+};
+
+export const getTransportationCostPerGT = (
+  distance: number,
+  duration: number,
+  dieselFuelPrice: number,
+  payload: number
+) => {
   /*
 
     2* cause you have to drive back
@@ -28,7 +66,7 @@ export const getTransportationCost = (distance: number, duration: number, fuelCo
 
   const labor = DRIVERS_PER_TRUCK * TRUCK_LABOR * hours;
 
-  const fuel = (1 / MILES_PER_GALLON) * fuelCost * miles;
+  const fuel = (1 / MILES_PER_GALLON) * dieselFuelPrice * miles;
 
   let cost = OIL_ETC_COST * miles + fuel + labor;
 

--- a/transportation.ts
+++ b/transportation.ts
@@ -1,15 +1,15 @@
 import { ClusterResult, YearlyTripResults } from 'models/types';
 import OSRM from 'osrm';
 
-const TRUCK_LABOR = 23.29; // changed from 22.74 according to BLS 2019
+// 2020 Median Pay for Heavy and Tractor-trailer Truck Drivers according to BLS
+// https://www.bls.gov/ooh/transportation-and-material-moving/heavy-and-tractor-trailer-truck-drivers.htm
+const TRUCK_LABOR = 22.66;
 const DRIVERS_PER_TRUCK = 1.67;
 const MILES_PER_GALLON = 6;
 const OIL_ETC_COST = 0.35; // $/mile
-export const KM_TO_MILES = 0.621371;
-export const TONS_PER_TRUCK = 25; // frcs assumption
-// 17.33 in metric tons, multiply by constant to get into short tons
+const KM_TO_MILES = 0.621371;
 
-export const getTransportationCost = (distance: number, duration: number, fuelCost: number) => {
+export const getTransportationCost = (distance: number, duration: number, fuelCost: number, payload: number) => {
   /*
 
     2* cause you have to drive back
@@ -32,7 +32,7 @@ export const getTransportationCost = (distance: number, duration: number, fuelCo
 
   let cost = OIL_ETC_COST * miles + fuel + labor;
 
-  cost = cost / TONS_PER_TRUCK + 1.11; // add $1.11 fixed cost to avoid unrealistic cost when distance is small
+  cost = cost / payload + 1.11; // add $1.11 fixed cost to avoid unrealistic cost when distance is small
 
   return cost;
 };


### PR DESCRIPTION
Our current implementation assumes trucks always have a full payload of 25 green tons. By modifying the transportation model and making payload another model input, we should be able to get a more accurate estimation of transportation cost.  