### PR TITLE
update lca and frcs packages to the latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
   },
   "dependencies": {
     "@types/cors": "^2.8.6",
-    "@ucdavis/frcs": "^1.1.1",
-    "@ucdavis/lca": "^1.1.0",
+    "@ucdavis/frcs": "^1.1.2",
+    "@ucdavis/lca": "^1.1.1",
     "@ucdavis/tea": "^1.2.0",
     "body-parser": "^1.19.0",
     "connect-timeout": "^1.9.0",


### PR DESCRIPTION
Update lca and frcs npm packages to their latest versions. #33 #43  

The issue of CI (carbon intensity) values does not seem to be related to the package version. I ran the program locally before and after updating the lca package version, the CI value does not change and looks good to me for that individual year. I checked the latest changes I made to the lca package and they have nothing to do with CI. I suspect the issue might be that the front end is not using the correct variables for CI. 