### PR TITLE
only process move-in if needed

### DIFF
--- a/processDistance.ts
+++ b/processDistance.ts
@@ -92,88 +92,11 @@ export const processClustersByDistance = async (
       console.log(`year:${year} selecting clusters...`);
       await selectClusters(osrm, params, clusters, results, lcaTotals, [], []);
 
-      let totalMoveInDistance = 0;
-
-      if (results.clusters.length > 500) {
-        console.log('lots of clusters, breaking into chunks');
-
-        const clusterCoordinates = results.clusters.map((c) => [c.center_lng, c.center_lat]);
-
-        const maxClustersPerChunk = 4000;
-
-        let chunkedClusters: any[] = [];
-        let bias = 1.5; // multiply stdev with this factor, the smaller the more clusters
-        chunkedClusters = geocluster(clusterCoordinates, bias);
-
-        // we want to make sure there are no clusters with more than maxClustersPerChunk
-        while (Math.max(...chunkedClusters.map((cc) => cc.elements.length)) > maxClustersPerChunk) {
-          console.log(`clusters too large with bias ${bias}, retrying with smaller bias`);
-          bias = bias * 0.8; // make the stdev smaller to get more clusters
-          chunkedClusters = geocluster(clusterCoordinates, bias);
-        }
-
-        console.log('number of chunks:', chunkedClusters.length);
-        console.log('clusters in chunk1:' + chunkedClusters[0].elements.length);
-
-        for (let i = 0; i < chunkedClusters.length; i++) {
-          const chunk = chunkedClusters[i];
-
-          const clustersInChunk = chunk.elements.map(
-            (latlng: number[]) =>
-              ({
-                center_lng: latlng[0],
-                center_lat: latlng[1],
-              } as TreatedCluster)
-          );
-
-          console.log(
-            `calculating move in distance on ${clustersInChunk.length} clusters in chunk ${
-              i + 1
-            }...`
-          );
-          const t0_chunk = performance.now();
-          const chunkedMoveInTripResults = await getMoveInTrip(
-            osrm,
-            params.facilityLat,
-            params.facilityLng,
-            clustersInChunk
-          );
-          const t1_chunk = performance.now();
-          console.log(
-            `Running took ${t1_chunk - t0_chunk} milliseconds, move in distance: ${
-              chunkedMoveInTripResults.distance
-            }.`
-          );
-
-          totalMoveInDistance += chunkedMoveInTripResults.distance;
-        }
-      } else {
-        // not that many clusters, so don't bother chunking
-        console.log(`calculating move in distance on ${clusters.length} clusters...`);
-        const t0 = performance.now();
-        const moveInTripResults = await getMoveInTrip(
-          osrm,
-          params.facilityLat,
-          params.facilityLng,
-          results.clusters
-        );
-        const t1 = performance.now();
-        console.log(
-          `Running took ${t1 - t0} milliseconds, move in distance: ${moveInTripResults.distance}.`
-        );
-
-        totalMoveInDistance = moveInTripResults.distance;
-      }
-
-      // we only update the move in distance if it is applicable for this type of treatment & system
       let moveInDistance = 0;
-      if (
-        results.totalFeedstock > 0 &&
-        results.clusters.length < 5000 &&
-        params.system === 'Ground-Based CTL'
-      ) {
-        console.log('updating move in distance of');
-        moveInDistance = totalMoveInDistance;
+
+      if (doesNeedMoveIn(results, params)) {
+        console.log('move in distance required, calculating');
+        moveInDistance = await calculateMoveInDistance(osrm, clusters, results, params);
       } else {
         console.log(
           `skipping updating move in distance, totalBiomass: ${results.totalFeedstock}, # of clusters: ${results.clusters.length}`
@@ -259,17 +182,6 @@ export const processClustersByDistance = async (
 
       results.cashFlow = cashFlow;
 
-      // TODO: probably don't need geo info about cluster usage for distance processing
-
-      // const geoJson = await getGeoJson(db, results.clusterNumbers, results.clusters);
-      // results.geoJson = geoJson;
-      // const errorGeoJson = await getErrorGeoJson(
-      //   db,
-      //   results.errorClusterNumbers,
-      //   results.errorClusters
-      // );
-      // results.errorGeoJson = errorGeoJson;
-
       resolve(results);
     } catch (e) {
       console.log('ERROR!');
@@ -277,6 +189,90 @@ export const processClustersByDistance = async (
       reject(e.message);
     }
   });
+};
+
+const doesNeedMoveIn = (results: YearlyResult, params: RequestByDistanceParams): boolean => {
+  return results.totalFeedstock > 0 && params.system === 'Ground-Based CTL';
+};
+
+const calculateMoveInDistance = async (
+  osrm: OSRM,
+  clusters: TreatedCluster[],
+  results: YearlyResult,
+  params: RequestByDistanceParams
+) => {
+  let totalMoveInDistance = 0;
+
+  if (results.clusters.length > 500) {
+    console.log('lots of clusters, breaking into chunks');
+
+    const clusterCoordinates = results.clusters.map((c) => [c.center_lng, c.center_lat]);
+
+    const maxClustersPerChunk = 4000;
+
+    let chunkedClusters: any[] = [];
+    let bias = 1.5; // multiply stdev with this factor, the smaller the more clusters
+    chunkedClusters = geocluster(clusterCoordinates, bias);
+
+    // we want to make sure there are no clusters with more than maxClustersPerChunk
+    while (Math.max(...chunkedClusters.map((cc) => cc.elements.length)) > maxClustersPerChunk) {
+      console.log(`clusters too large with bias ${bias}, retrying with smaller bias`);
+      bias = bias * 0.8; // make the stdev smaller to get more clusters
+      chunkedClusters = geocluster(clusterCoordinates, bias);
+    }
+
+    console.log('number of chunks:', chunkedClusters.length);
+    console.log('clusters in chunk1:' + chunkedClusters[0].elements.length);
+
+    for (let i = 0; i < chunkedClusters.length; i++) {
+      const chunk = chunkedClusters[i];
+
+      const clustersInChunk = chunk.elements.map(
+        (latlng: number[]) =>
+          ({
+            center_lng: latlng[0],
+            center_lat: latlng[1],
+          } as TreatedCluster)
+      );
+
+      console.log(
+        `calculating move in distance on ${clustersInChunk.length} clusters in chunk ${i + 1}...`
+      );
+      const t0_chunk = performance.now();
+      const chunkedMoveInTripResults = await getMoveInTrip(
+        osrm,
+        params.facilityLat,
+        params.facilityLng,
+        clustersInChunk
+      );
+      const t1_chunk = performance.now();
+      console.log(
+        `Running took ${t1_chunk - t0_chunk} milliseconds, move in distance: ${
+          chunkedMoveInTripResults.distance
+        }.`
+      );
+
+      totalMoveInDistance += chunkedMoveInTripResults.distance;
+    }
+  } else {
+    // not that many clusters, so don't bother chunking
+    console.log(`calculating move in distance on ${clusters.length} clusters...`);
+    const t0 = performance.now();
+    const moveInTripResults = await getMoveInTrip(
+      osrm,
+      params.facilityLat,
+      params.facilityLng,
+      results.clusters
+    );
+    const t1 = performance.now();
+    console.log(
+      `Running took ${t1 - t0} milliseconds, move in distance: ${moveInTripResults.distance}.`
+    );
+
+    totalMoveInDistance = moveInTripResults.distance;
+  }
+
+  return totalMoveInDistance;
 };
 
 const getClusters = async (


### PR DESCRIPTION
for the supply curve -- for regular yearly processing we always run the move-in, at least for now, because we always use the move-in route for map route display purposes.

If we want to speed things up in the future we can delay running the move-in until the user wants to view the full route, like we do with the trip service.  But since we know there aren't a ton of clusters this isn't a huge problem but more an optimization.