### PR TITLE
Sort clusters by delivered cost per ton feedstock

### DIFF
--- a/models/ProcessedTreatedCluster.ts
+++ b/models/ProcessedTreatedCluster.ts
@@ -1,0 +1,16 @@
+import { OutputVarMod } from '@ucdavis/frcs/out/systems/frcs.model';
+import { TreatedCluster } from './treatedcluster';
+
+export interface ProcessedTreatedCluster extends TreatedCluster {
+  feedstock: number;
+  coproduct: number;
+  frcsResult: OutputVarMod;
+  feedstockHarvestCost: number;
+  coproductHarvestCost: number;
+  transportationCost: number;
+  diesel: number;
+  gasoline: number;
+  juetFuel: number;
+  distance: number; // one-way transportation distance
+  transportationDistance: number; // total transportation distance
+}

--- a/processYear.ts
+++ b/processYear.ts
@@ -173,7 +173,6 @@ export const processClustersForYear = async (
       let moveInDistance = 0;
       if (
         results.totalFeedstock > 0 &&
-        results.clusters.length < 5000 &&
         params.system === 'Ground-Based CTL'
       ) {
         console.log('updating move in distance of');


### PR DESCRIPTION
1. Process clusters: run FRCS and OSRM to compute biomass amount, harvest cost, and transportation-related results
2. Sort clusters by delivered cost per ton feedstock. The unit delivered cost is computed by dividing the sum of feedstock harvest cost and transportation cost by feedstock amount
3. Select the sorted clusters such that the total feedstock amount >= annual feedstock requirement/biomass target
close #62 