### PR TITLE
remove unloadingCost from backend

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -124,14 +124,10 @@ app.post('/initialProcessing', async (req, res) => {
     `nearest substation: ${nearestSubstation.substation_name} is ${distanceToNearestSubstation} miles away`
   );
   const transmissionResults = transmission(params.transmission);
+  console.log(`transmission cost: ${transmissionResults.AllCost}`);
 
-  const additionalCosts =
-    transmissionResults.AllCost + (params.includeUnloadingCost ? params.unloadingCost : 0);
-  console.log(
-    `additionalCosts: ${additionalCosts}: ${transmissionResults.AllCost}, ${params.includeUnloadingCost}: ${params.unloadingCost}`
-  );
   const teaInputs: any = { ...params.teaInputs };
-  teaInputs.CapitalCost += additionalCosts;
+  teaInputs.CapitalCost += transmissionResults.AllCost;
   console.log(JSON.stringify(teaInputs));
   const teaOutput: OutputModGPO | OutputModCHP | OutputModGP = await getTeaOutputs(
     params.teaModel,

--- a/models/types.ts
+++ b/models/types.ts
@@ -83,8 +83,6 @@ export interface RequestParamsAllYears {
   transmission: InputModTransimission;
   teaModel: string;
   teaInputs: InputModGPO | InputModCHP | InputModGP; // | InputModHydrogen;
-  includeUnloadingCost: boolean;
-  unloadingCost: number; // default to 10,000
 }
 
 export interface AllYearsResults {

--- a/test.ts
+++ b/test.ts
@@ -97,8 +97,6 @@
 //         Zone12: 0
 //       }
 //     },
-//     unloadingCost: 10000,
-//     includeUnloadingCost: true
 //   };
 
 //   const systems = [


### PR DESCRIPTION
Unloading cost is part of capital cost. In order to scale unloading cost along with capital cost, we add unloading cost to capital cost first and then scale capital cost. Essentially, we want to add unloading cost to capital cost before passing to the backend. 