### PR TITLE
Update frcs npm to v1.2.3

### DIFF
--- a/frcsInputCalculations.ts
+++ b/frcsInputCalculations.ts
@@ -27,8 +27,8 @@ export const getFrcsInputs = (
     calcResidueWeightCT(cluster) / // dry short tons
     (1 - moistureContent / 100); // convert to green short tons
   const residueFractionCT = residueWeightCT / boleWeightCT;
-  const volumeCT = calcVolumeCT(cluster);
   const removalsCT = calcRemovalsCT(cluster);
+  const volumeCT = calcVolumeCT(cluster) / removalsCT;
 
   const boleWeightSLT =
     calcBoleWeightSLT(cluster) / // dry short tons
@@ -37,8 +37,8 @@ export const getFrcsInputs = (
     calcResidueWeightSLT(cluster) / // dry short tons
     (1 - moistureContent / 100); // convert to green short tons
   const residueFractionSLT = residueWeightSLT / boleWeightSLT;
-  const volumeSLT = calcVolumeSLT(cluster);
   const removalsSLT = calcRemovalsSLT(cluster);
+  const volumeSLT = calcVolumeSLT(cluster) / removalsSLT;
 
   const boleWeightLLT =
     calcBoleWeightLLT(cluster) / // dry short tons
@@ -47,8 +47,8 @@ export const getFrcsInputs = (
     calcResidueWeightLLT(cluster) / // dry short tons
     (1 - moistureContent / 100); // convert to green short tons
   const residueFractionLLT = residueWeightLLT / boleWeightLLT;
-  const volumeLLT = calcVolumeLLT(cluster, system);
   const removalsLLT = calcRemovalsLLT(cluster, system);
+  const volumeLLT = calcVolumeLLT(cluster, system) / removalsLLT;
 
   const frcsInputs: FrcsInputs = {
     system: system,

--- a/index.ts
+++ b/index.ts
@@ -338,7 +338,7 @@ app.post('/testCluster', async (req, res) => {
       params.residueRecovFracWT,
       params.residueRecovFracCTL
     );
-    const residueBiomass = frcsResult.biomass.yieldPerAcre * cluster.area;
+    const residueBiomass = frcsResult.residual.yieldPerAcre * cluster.area;
     const transportationCostTotal = getTransportationCostTotal(
       residueBiomass,
       distance,
@@ -353,7 +353,7 @@ app.post('/testCluster', async (req, res) => {
       residueBiomass: residueBiomass,
       distance: distance,
       combinedCost: frcsResult.total.costPerAcre * cluster.area,
-      residueCost: frcsResult.biomass.costPerAcre * cluster.area,
+      residueCost: frcsResult.residual.costPerAcre * cluster.area,
       transportationCost: transportationCostTotal,
       frcsInputs: {
         boleWeightCT,

--- a/package-lock.json
+++ b/package-lock.json
@@ -408,9 +408,9 @@
       }
     },
     "@ucdavis/frcs": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@ucdavis/frcs/-/frcs-1.2.1.tgz",
-      "integrity": "sha512-6n3tLsoHZ4Wy0wbmYSAVLzIoJ8hUTuV+swqLImfdcuS9bsOYHHzjN3pdYVMUPYjAKdx3fbkZAd0st8iMEvVi8Q==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@ucdavis/frcs/-/frcs-1.2.2.tgz",
+      "integrity": "sha512-W2/o9d1n5YQ3wu+e2o2ntMM23wFo3pRSVRO0HpojCMPGhFwh5FxurU8miQRIoVfh4pzpJDEhB+mZOHSKyHBP7A==",
       "requires": {
         "body-parser": "^1.18.3",
         "express": "^4.16.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -408,9 +408,9 @@
       }
     },
     "@ucdavis/frcs": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@ucdavis/frcs/-/frcs-1.2.2.tgz",
-      "integrity": "sha512-W2/o9d1n5YQ3wu+e2o2ntMM23wFo3pRSVRO0HpojCMPGhFwh5FxurU8miQRIoVfh4pzpJDEhB+mZOHSKyHBP7A==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@ucdavis/frcs/-/frcs-1.2.3.tgz",
+      "integrity": "sha512-M3Y8B79auN5bWiZQtwlNhaxIxKXBq6/DCGpYpPBJj79HWNvJ6DgYR//W4M/kXzZaX8rCKNPkjxyQYIayZWW6rA==",
       "requires": {
         "body-parser": "^1.18.3",
         "express": "^4.16.4",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@types/cors": "^2.8.12",
-    "@ucdavis/frcs": "^1.2.1",
+    "@ucdavis/frcs": "^1.2.2",
     "@ucdavis/lca": "^1.5.3",
     "@ucdavis/tea": "^1.4.0",
     "applicationinsights": "^2.1.9",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@types/cors": "^2.8.12",
-    "@ucdavis/frcs": "^1.2.2",
+    "@ucdavis/frcs": "^1.2.3",
     "@ucdavis/lca": "^1.5.3",
     "@ucdavis/tea": "^1.4.0",
     "applicationinsights": "^2.1.9",

--- a/runFrcs.ts
+++ b/runFrcs.ts
@@ -1,4 +1,4 @@
-import { runFrcs } from '@ucdavis/frcs';
+import { getFrcsOutputs } from '@ucdavis/frcs';
 import { getFrcsInputs, getFrcsInputsTest } from './frcsInputCalculations';
 import { TreatedCluster } from './models/treatedcluster';
 
@@ -26,7 +26,7 @@ export const runFrcsOnCluster = async (
     residueRecovFracWT,
     residueRecovFracCTL
   );
-  const clusterFrcsOutput = runFrcs(frcsInputs);
+  const clusterFrcsOutput = getFrcsOutputs(frcsInputs);
   return clusterFrcsOutput;
 };
 
@@ -74,7 +74,7 @@ export const testRunFrcsOnCluster = async (
     residueRecovFracCTL
   );
   console.log(JSON.stringify(frcsInputs));
-  const frcsResult = runFrcs(frcsInputs);
+  const frcsResult = getFrcsOutputs(frcsInputs);
   return {
     frcsInputs,
     boleWeightCT,


### PR DESCRIPTION
- Correct calculations of tree volume for FRCS inputs
- Use the latest FRCS npm package (version 1.2.3)
- Update model and functions from FRCS
- Add residual diesel from move-in to total diesel