### PR TITLE
New API route for processing move-in

### DIFF
--- a/processYear.ts
+++ b/processYear.ts
@@ -160,28 +160,25 @@ export const processClustersForYear = async (
         `annualGeneration: ${params.annualGeneration}, radius: ${results.radius}, # of clusters: ${results.numberOfClusters}`
       );
 
-      console.log(`calculating move in distance on ${results.clusters.length} clusters...`);
-      const t0 = performance.now();
-      const moveInTripResults = await getMoveInTrip(
-        osrm,
-        params.facilityLat,
-        params.facilityLng,
-        results.clusters
-      );
-      const t1 = performance.now();
-      console.log(
-        `Running took ${t1 - t0} milliseconds, move in distance: ${moveInTripResults.distance}.`
-      );
-
-      trackMetric(`moveInDistance for ${results.clusters.length} clusters`, t1 - t0);
-
-      results.tripGeometries = moveInTripResults.trips.map((t) => t.geometry);
-
       /*** move-in cost calculation ***/
-      // we only update the move in distance if it is applicable for this type of treatment & system
+      // we only calculate the move in distance if it is applicable for this type of treatment & system
       let moveInDistance = 0;
       if (results.totalFeedstock > 0 && params.system === 'Ground-Based CTL') {
-        console.log('updating move in distance of');
+        console.log(`calculating move in distance on ${results.clusters.length} clusters...`);
+        const t0 = performance.now();
+        const moveInTripResults = await getMoveInTrip(
+          osrm,
+          params.facilityLat,
+          params.facilityLng,
+          results.clusters
+        );
+        const t1 = performance.now();
+        console.log(
+          `Running took ${t1 - t0} milliseconds, move in distance: ${moveInTripResults.distance}.`
+        );
+
+        trackMetric(`moveInDistance for ${results.clusters.length} clusters`, t1 - t0);
+
         moveInDistance = moveInTripResults.distance;
       } else {
         console.log(

--- a/swagger.json
+++ b/swagger.json
@@ -14,21 +14,15 @@
   },
   "host": "virtserver.swaggerhub.com",
   "basePath": "/ucdavis/CECDSS-Backend/1.0.0",
-  "schemes": [
-    "https"
-  ],
+  "schemes": ["https"],
   "paths": {
     "/initialProcessing": {
       "post": {
-        "tags": [
-          "main"
-        ],
+        "tags": ["main"],
         "summary": "determines transmissions and techno-economic results across all years",
         "description": "Used for initial processing of data before calling /process for individual year\n",
         "operationId": "initialProcessing",
-        "produces": [
-          "application/json"
-        ],
+        "produces": ["application/json"],
         "parameters": [
           {
             "in": "body",
@@ -55,15 +49,11 @@
     },
     "/process": {
       "post": {
-        "tags": [
-          "main"
-        ],
+        "tags": ["main"],
         "summary": "process facility biomass for single year",
         "description": "Used for annual biomass supply location and optimization\n",
         "operationId": "process",
-        "produces": [
-          "application/json"
-        ],
+        "produces": ["application/json"],
         "parameters": [
           {
             "in": "body",
@@ -90,15 +80,11 @@
     },
     "/processRoutes": {
       "post": {
-        "tags": [
-          "main"
-        ],
+        "tags": ["main"],
         "summary": "Get routing information for all passed clusters",
         "description": "Used to generate transportation route overlays to each cluster\n",
         "operationId": "processRoutes",
-        "produces": [
-          "application/json"
-        ],
+        "produces": ["application/json"],
         "parameters": [
           {
             "in": "body",
@@ -123,6 +109,41 @@
           },
           "400": {
             "description": "bad input parameter"
+          }
+        }
+      }
+    },
+    "/processMoveIn": {
+      "post": {
+        "tags": ["main"],
+        "summary": "Get move-in trip information for all passed clusters",
+        "description": "Used to generate move-in trip single route that can access all clusters\n",
+        "operationId": "processMoveIn",
+        "produces": ["application/json"],
+        "parameters": [
+          {
+            "in": "body",
+            "name": "params",
+            "description": "Cluster information along with facility details",
+            "required": false,
+            "schema": {
+              "$ref": "#/definitions/RequestByRoutesParams"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "success",
+            "schema": {
+              "title": "YearlyResult.tripGeometries.[]",
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Geometry"
+              }
+            }
+          },
+          "400": {
+            "description": "too many clusters"
           }
         }
       }
@@ -256,13 +277,7 @@
     },
     "RequestParamsAllYears": {
       "type": "object",
-      "required": [
-        "facilityLat",
-        "facilityLng",
-        "teaInputs",
-        "teaModel",
-        "transmission"
-      ],
+      "required": ["facilityLat", "facilityLng", "teaInputs", "teaModel", "transmission"],
       "properties": {
         "facilityLat": {
           "type": "number",
@@ -291,11 +306,7 @@
     },
     "RequestByRoutesParams": {
       "type": "object",
-      "required": [
-        "clusters",
-        "facilityLat",
-        "facilityLng"
-      ],
+      "required": ["clusters", "facilityLat", "facilityLng"],
       "properties": {
         "facilityLat": {
           "type": "number",
@@ -313,10 +324,7 @@
     },
     "Geometry": {
       "type": "object",
-      "required": [
-        "coodinates",
-        "type"
-      ],
+      "required": ["coodinates", "type"],
       "properties": {
         "coodinates": {
           "type": "array",


### PR DESCRIPTION
Compliments the existing processRoutes method and does the same thing except for a single move-in route.  This frees the processYear from the need to always calculate move-in even if it isn't needed, and in all cases frees up a lot of bytes from geometry trip info.  Now the front-end will load this only when the client asks for the move-in layer.