### PR TITLE
Update LCA, add unloading cost, and calculate move-in

### DIFF
--- a/equipment.ts
+++ b/equipment.ts
@@ -1,0 +1,74 @@
+import { SystemTypes } from '@ucdavis/frcs/out/model';
+
+// Purchase price as of Dec 02
+const chainsawPirce = 700;
+const fbuncherPrice = (150000 + 310000 + 310000) / 3;
+const harvesterPrice = 400000;
+const skidderPrice = 170000;
+const forwarderPrice = 275000;
+const yarderPrice = 245000;
+const processorPrice = 350000;
+const loaderPrice = 220000;
+const chipperPrice = 250000;
+const bundlerPrice = 450000;
+
+// Machine life (years)
+const chainsawLife = 1;
+const fbuncherLife = 4;
+const harvesterLife = 4;
+const skidderLife = 4;
+const forwarderLife = 4;
+const yarderLife = 10;
+const processorLife = 5;
+const loaderLife = 5;
+const chipperLife = 5;
+const bundlerLife = 5;
+
+export const getEquipmentPrice = (system: string, year: number) => {
+  // Purchase price as of Dec 02
+  const chainsaw = year % chainsawLife === 0 ? chainsawPirce : 0;
+  const fbuncher = year % fbuncherLife === 0 ? fbuncherPrice : 0;
+  const harvester = year % harvesterLife === 0 ? harvesterPrice : 0;
+  const skidder = year % skidderLife === 0 ? skidderPrice : 0;
+  const forwarder = year % forwarderLife === 0 ? forwarderPrice : 0;
+  const yarder = year % yarderLife === 0 ? yarderPrice : 0;
+  const processor = year % processorLife === 0 ? processorPrice : 0;
+  const loader = year % loaderLife === 0 ? loaderPrice : 0;
+  const chipper = year % chipperLife === 0 ? chipperPrice : 0;
+  const bundler = year % bundlerLife === 0 ? bundlerPrice : 0;
+  let equipmentPrice = 0;
+  // chipper and bundler is always required for this project
+  switch (system) {
+    case SystemTypes.groundBasedMechWt:
+      equipmentPrice = fbuncher + skidder + processor + loader + chipper + chainsaw;
+      break;
+    case SystemTypes.groundBasedCtl:
+      equipmentPrice = harvester + forwarder + loader + chipper + bundler;
+      break;
+    case SystemTypes.groundBasedManualWt:
+      equipmentPrice = skidder + processor + loader + chipper + chainsaw;
+      break;
+    case SystemTypes.groundBasedManualLog:
+      equipmentPrice = skidder + loader + chipper + chainsaw;
+      break;
+    case SystemTypes.cableManualWtLog:
+      equipmentPrice = yarder + loader + chipper + chainsaw;
+      break;
+    case SystemTypes.cableManualWt:
+      equipmentPrice = yarder + processor + loader + chipper + chainsaw;
+      break;
+    case SystemTypes.cableManualLog:
+      equipmentPrice = yarder + loader + chipper + chainsaw;
+      break;
+    case SystemTypes.cableCtl:
+      equipmentPrice = harvester + yarder + loader + chipper;
+      break;
+    case SystemTypes.helicopterManualLog:
+      equipmentPrice = loader + chipper + chainsaw;
+      break;
+    case SystemTypes.helicopterCtl:
+      equipmentPrice = harvester + loader + chipper;
+      break;
+  }
+  return equipmentPrice;
+};

--- a/index.ts
+++ b/index.ts
@@ -155,7 +155,7 @@ app.post('/initialProcessing', async (req, res) => {
     console.log(`transmission cost: ${transmissionResults.AllCost}`);
 
     const teaInputs: any = { ...params.teaInputs };
-    teaInputs.CapitalCost += transmissionResults.AllCost;
+    // teaInputs.CapitalCost += transmissionResults.AllCost;
     console.log(JSON.stringify(teaInputs));
     const teaOutput: OutputModGPO | OutputModCHP | OutputModGP = await getTeaOutputs(
       params.teaModel,

--- a/models/types.ts
+++ b/models/types.ts
@@ -49,6 +49,7 @@ export interface RequestParams {
   wageTruckDriver: number;
   driverBenefits: number;
   oilCost: number;
+  capitalCost: number; // combine capital cost = facility capital + transmission cost + unloading cost
 }
 
 export interface RequestByDistanceParams {

--- a/package-lock.json
+++ b/package-lock.json
@@ -419,9 +419,9 @@
       }
     },
     "@ucdavis/lca": {
-      "version": "1.5.3",
-      "resolved": "https://registry.npmjs.org/@ucdavis/lca/-/lca-1.5.3.tgz",
-      "integrity": "sha512-D3+XJsM01ypTtMjeQENbFhMwuG2qckNouffiJKnQRi5sG4Lq/YWpZR1CZfI6gwtXprO7l3oNNes6e8lR5bWU2Q==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@ucdavis/lca/-/lca-1.6.0.tgz",
+      "integrity": "sha512-Ze3vIXKwaDtQBVD7okDqS5m6ss7EXr6mP2AdXuEv8p7j/oAGpBNe3q5RUFN5wL1uPelmzUmbxk4immUppa493A==",
       "requires": {
         "express": "^4.16.4",
         "papaparse": "^5.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -408,9 +408,9 @@
       }
     },
     "@ucdavis/frcs": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@ucdavis/frcs/-/frcs-1.2.4.tgz",
-      "integrity": "sha512-OJNjgLsNRp4c6An8Rmi1Y7oLTrqjuUDEn/E436zztxb3zhsW4IfIIDSkf4E0dswSJsoZ4PvjvTyV588NFRbivA==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@ucdavis/frcs/-/frcs-1.2.5.tgz",
+      "integrity": "sha512-idjraVHzn6vVmesFiQ9vclknEy2cCBPEh1BtdpYbD2wLlXYlGqEMjwYfI2pr7vZgwmKOYUJ9h9I5HG2hqWM/zw==",
       "requires": {
         "body-parser": "^1.18.3",
         "express": "^4.16.4",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@types/cors": "^2.8.12",
-    "@ucdavis/frcs": "^1.2.4",
+    "@ucdavis/frcs": "^1.2.5",
     "@ucdavis/lca": "^1.6.0",
     "@ucdavis/tea": "^1.4.0",
     "applicationinsights": "^2.1.9",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "@types/cors": "^2.8.12",
     "@ucdavis/frcs": "^1.2.4",
-    "@ucdavis/lca": "^1.5.3",
+    "@ucdavis/lca": "^1.6.0",
     "@ucdavis/tea": "^1.4.0",
     "applicationinsights": "^2.1.9",
     "body-parser": "^1.19.0",

--- a/processDistance.ts
+++ b/processDistance.ts
@@ -141,8 +141,13 @@ export const processClustersByDistance = async (
       results.lcaResults = lca;
 
       const moistureContentPercentage = params.moistureContent / 100.0;
-
       const TONNE_TO_TON = 1.10231; // 1 metric ton = 1.10231 short tons
+
+      // unloading
+      const unloadingCostPerDryTon =
+        (0.16667 * (44.31 + 1.6 * params.wageTruckDriver) + 0.2 * 1.67 * params.wageTruckDriver) /
+        (FULL_TRUCK_PAYLOAD * (1 - moistureContentPercentage));
+
       // calculate dry values ($ / dry metric ton)
       results.totalDryFeedstock =
         (results.totalFeedstock * (1 - moistureContentPercentage)) / TONNE_TO_TON;
@@ -151,7 +156,7 @@ export const processClustersByDistance = async (
 
       results.harvestCostPerDryTon = results.totalHarvestCost / results.totalDryFeedstock;
       results.transportationCostPerDryTon =
-        results.totalTransportationCost / results.totalDryFeedstock;
+        results.totalTransportationCost / results.totalDryFeedstock + unloadingCostPerDryTon;
       results.moveInCostPerDryTon = results.totalMoveInCost / results.totalDryFeedstock;
       results.feedstockCostPerTon =
         results.harvestCostPerDryTon +

--- a/processDistance.ts
+++ b/processDistance.ts
@@ -11,6 +11,7 @@ import {
   genericCombinedHeatPower,
   genericPowerOnly,
 } from '@ucdavis/tea/utility';
+import { getEquipmentPrice } from 'equipment';
 import geocluster from 'geocluster';
 import { getDistance } from 'geolib';
 import { Knex } from 'knex';
@@ -126,12 +127,15 @@ export const processClustersByDistance = async (
 
       results.numberOfClusters = results.clusterNumbers.length;
 
+      /*** run LCA ***/
       const lcaInputs: LcaInputs = {
         technology: params.teaModel,
-        diesel: lcaTotals.totalDiesel / params.annualGeneration, // gal/MWh
-        gasoline: lcaTotals.totalGasoline / params.annualGeneration, // gal/MWh
-        jetfuel: lcaTotals.totalJetFuel / params.annualGeneration, // gal/MWh
-        distance: (lcaTotals.totalTransportationDistance * KM_TO_MILES) / params.annualGeneration, // km/MWh
+        diesel: lcaTotals.totalDiesel / params.annualGeneration, // gal/kWh
+        gasoline: lcaTotals.totalGasoline / params.annualGeneration, // gal/kWh
+        jetfuel: lcaTotals.totalJetFuel / params.annualGeneration, // gal/kWh
+        distance: (lcaTotals.totalTransportationDistance * KM_TO_MILES) / params.annualGeneration, // miles/kWh
+        construction: 0,
+        equipment: 0,
       };
 
       const lca = await runLca(lcaInputs);

--- a/processDistance.ts
+++ b/processDistance.ts
@@ -98,7 +98,13 @@ export const processClustersByDistance = async (
 
       if (results.totalFeedstock > 0) {
         console.log('move in distance required, calculating');
-        moveInDistance = await calculateMoveInDistance(osrm, clusters, results, params);
+        moveInDistance = await calculateMoveInDistance(
+          osrm,
+          clusters,
+          results,
+          params.facilityLat,
+          params.facilityLng
+        );
       } else {
         console.log(
           `skipping updating move in distance, totalBiomass: ${results.totalFeedstock}, # of clusters: ${results.clusters.length}`
@@ -207,7 +213,8 @@ const calculateMoveInDistance = async (
   osrm: OSRM,
   clusters: TreatedCluster[],
   results: YearlyResult,
-  params: RequestByDistanceParams
+  facilityLat: number,
+  facilityLng: number
 ) => {
   let totalMoveInDistance = 0;
 
@@ -225,11 +232,11 @@ const calculateMoveInDistance = async (
     const sortedClusters = results.clusters.sort(
       (a, b) =>
         getDistance(
-          { latitude: params.facilityLat, longitude: params.facilityLng },
+          { latitude: facilityLat, longitude: facilityLng },
           { latitude: a.center_lat, longitude: a.center_lng }
         ) -
         getDistance(
-          { latitude: params.facilityLat, longitude: params.facilityLng },
+          { latitude: facilityLat, longitude: facilityLng },
           { latitude: b.center_lat, longitude: b.center_lng }
         )
     );
@@ -259,8 +266,8 @@ const calculateMoveInDistance = async (
       const t0_chunk = performance.now();
       const chunkedMoveInTripResults = await getMoveInTrip(
         osrm,
-        params.facilityLat,
-        params.facilityLng,
+        facilityLat,
+        facilityLng,
         clustersInGroup
       );
       const t1_chunk = performance.now();
@@ -276,12 +283,7 @@ const calculateMoveInDistance = async (
     // not that many clusters, so don't bother chunking
     console.log(`calculating move in distance on ${clusters.length} clusters...`);
     const t0 = performance.now();
-    const moveInTripResults = await getMoveInTrip(
-      osrm,
-      params.facilityLat,
-      params.facilityLng,
-      results.clusters
-    );
+    const moveInTripResults = await getMoveInTrip(osrm, facilityLat, facilityLng, results.clusters);
     const t1 = performance.now();
     console.log(
       `Running took ${t1 - t0} milliseconds, move in distance: ${moveInTripResults.distance}.`

--- a/processDistance.ts
+++ b/processDistance.ts
@@ -11,7 +11,6 @@ import {
   genericCombinedHeatPower,
   genericPowerOnly,
 } from '@ucdavis/tea/utility';
-import { getEquipmentPrice } from 'equipment';
 import geocluster from 'geocluster';
 import { getDistance } from 'geolib';
 import { Knex } from 'knex';

--- a/processDistance.ts
+++ b/processDistance.ts
@@ -100,7 +100,6 @@ export const processClustersByDistance = async (
         console.log('move in distance required, calculating');
         moveInDistance = await calculateMoveInDistance(
           osrm,
-          clusters,
           results,
           params.facilityLat,
           params.facilityLng
@@ -211,7 +210,6 @@ export const processClustersByDistance = async (
 
 const calculateMoveInDistance = async (
   osrm: OSRM,
-  clusters: TreatedCluster[],
   results: YearlyResult,
   facilityLat: number,
   facilityLng: number
@@ -281,7 +279,7 @@ const calculateMoveInDistance = async (
     }
   } else {
     // not that many clusters, so don't bother chunking
-    console.log(`calculating move in distance on ${clusters.length} clusters...`);
+    console.log(`calculating move in distance on ${results.clusters.length} clusters...`);
     const t0 = performance.now();
     const moveInTripResults = await getMoveInTrip(osrm, facilityLat, facilityLng, results.clusters);
     const t1 = performance.now();

--- a/processDistance.ts
+++ b/processDistance.ts
@@ -11,19 +11,15 @@ import {
   genericCombinedHeatPower,
   genericPowerOnly,
 } from '@ucdavis/tea/utility';
-import geocluster from 'geocluster';
-import { getDistance } from 'geolib';
 import { Knex } from 'knex';
 import OSRM from 'osrm';
-import { performance } from 'perf_hooks';
 import { LCAresults } from './models/lcaModels';
 import { TreatedCluster } from './models/treatedcluster';
-import { ClusterResult, LCATotals, RequestByDistanceParams, YearlyResult } from './models/types';
+import { LCATotals, RequestByDistanceParams, YearlyResult } from './models/types';
 import { runFrcsOnCluster } from './runFrcs';
 import {
   calculateMoveInDistance,
   FULL_TRUCK_PAYLOAD,
-  getMoveInTrip,
   getTransportationCostTotal,
   KM_TO_MILES,
 } from './transportation';

--- a/processYear.ts
+++ b/processYear.ts
@@ -207,7 +207,7 @@ export const processClustersForYear = async (
       lcaTotals.totalDiesel += moveInOutputs.residualDiesel;
 
       const CPI2002 = 179.9;
-      const CPI2016 = 240.0075;
+      const CPI2021 = 266.236;
 
       /*** run LCA ***/
       const lcaInputs: LcaInputs = {
@@ -218,7 +218,7 @@ export const processClustersForYear = async (
         distance: (lcaTotals.totalTransportationDistance * KM_TO_MILES) / params.annualGeneration, // miles/kWh
         construction:
           params.year === params.firstYear
-            ? ((params.capitalCost / CPI2016) * CPI2002) / 1000 / params.annualGeneration
+            ? ((params.capitalCost / CPI2021) * CPI2002) / 1000 / params.annualGeneration
             : 0, // thousand$/kWh, assume the first year is 2016 for now
         equipment:
           getEquipmentPrice(params.system, params.year - params.firstYear) /

--- a/processYear.ts
+++ b/processYear.ts
@@ -232,6 +232,11 @@ export const processClustersForYear = async (
       console.log('lifeCycleEmissions = ', lca.lifeCycleEmissions);
       results.lcaResults = lca;
 
+      // unloading
+      const unloadingCostPerDryTon =
+        (0.16667 * (44.31 + 1.6 * params.wageTruckDriver) + 0.2 * 1.67 * params.wageTruckDriver) /
+        (FULL_TRUCK_PAYLOAD * (1 - moistureContentPercentage));
+
       // calculate dry values ($ / dry metric ton)
       results.totalDryFeedstock =
         (results.totalFeedstock * (1 - moistureContentPercentage)) / TONNE_TO_TON;
@@ -240,7 +245,7 @@ export const processClustersForYear = async (
 
       results.harvestCostPerDryTon = results.totalHarvestCost / results.totalDryFeedstock;
       results.transportationCostPerDryTon =
-        results.totalTransportationCost / results.totalDryFeedstock;
+        results.totalTransportationCost / results.totalDryFeedstock + unloadingCostPerDryTon;
       results.moveInCostPerDryTon = results.totalMoveInCost / results.totalDryFeedstock;
       results.feedstockCostPerTon =
         results.harvestCostPerDryTon +

--- a/processYear.ts
+++ b/processYear.ts
@@ -29,8 +29,8 @@ import {
 } from './models/types';
 import { runFrcsOnCluster } from './runFrcs';
 import {
+  calculateMoveInDistance,
   FULL_TRUCK_PAYLOAD,
-  getMoveInTrip,
   getTransportationCostTotal,
   KM_TO_MILES,
 } from './transportation';
@@ -165,22 +165,13 @@ export const processClustersForYear = async (
       // we only calculate the move in distance if it is applicable for this type of treatment & system
       let moveInDistance = 0;
       if (results.totalFeedstock > 0) {
-        console.log(`calculating move in distance on ${results.clusters.length} clusters...`);
-        const t0 = performance.now();
-        const moveInTripResults = await getMoveInTrip(
+        console.log('move in distance required, calculating');
+        moveInDistance = await calculateMoveInDistance(
           osrm,
+          results,
           params.facilityLat,
-          params.facilityLng,
-          results.clusters
+          params.facilityLng
         );
-        const t1 = performance.now();
-        console.log(
-          `Running took ${t1 - t0} milliseconds, move in distance: ${moveInTripResults.distance}.`
-        );
-
-        trackMetric(`moveInDistance for ${results.clusters.length} clusters`, t1 - t0);
-
-        moveInDistance = moveInTripResults.distance;
       } else {
         console.log(
           `skipping updating move in distance, totalBiomass: ${results.totalFeedstock}, # of clusters: ${results.clusters.length}`

--- a/processYear.ts
+++ b/processYear.ts
@@ -11,11 +11,11 @@ import {
   genericCombinedHeatPower,
   genericPowerOnly,
 } from '@ucdavis/tea/utility';
-import { getEquipmentPrice } from 'equipment';
 import { getBoundsOfDistance, getDistance } from 'geolib';
 import { Knex } from 'knex';
 import OSRM from 'osrm';
 import { performance } from 'perf_hooks';
+import { getEquipmentPrice } from './equipment';
 import { trackMetric } from './logging';
 import { LCAresults } from './models/lcaModels';
 import { ProcessedTreatedCluster } from './models/ProcessedTreatedCluster';

--- a/transportation.ts
+++ b/transportation.ts
@@ -1,4 +1,5 @@
-import { ClusterResult, YearlyTripResults } from 'models/types';
+import { getDistance } from 'geolib';
+import { ClusterResult, YearlyResult, YearlyTripResults } from 'models/types';
 import OSRM from 'osrm';
 
 const MILES_PER_GALLON = 6;
@@ -114,4 +115,89 @@ export const getMoveInTrip = (
       resolve(results);
     });
   });
+};
+
+export const calculateMoveInDistance = async (
+  osrm: OSRM,
+  results: YearlyResult,
+  facilityLat: number,
+  facilityLng: number
+) => {
+  let totalMoveInDistance = 0;
+
+  const maxClustersPerChunk = 2000;
+
+  if (results.clusters.length > maxClustersPerChunk) {
+    // want enough chunks so that we don't exceed max clusters per chunk
+    const numChunks = Math.ceil(results.clusters.length / maxClustersPerChunk);
+
+    console.log(
+      `${results.clusters.length} is too many clusters, breaking into ${numChunks} chunks`
+    );
+
+    // assuming facility coordinates are biomass coordinates
+    const sortedClusters = results.clusters.sort(
+      (a, b) =>
+        getDistance(
+          { latitude: facilityLat, longitude: facilityLng },
+          { latitude: a.center_lat, longitude: a.center_lng }
+        ) -
+        getDistance(
+          { latitude: facilityLat, longitude: facilityLng },
+          { latitude: b.center_lat, longitude: b.center_lng }
+        )
+    );
+
+    // break up into numChunks chunks by taking clusters in order
+    const groupedClusters = sortedClusters.reduce((resultArray, item, index) => {
+      const chunkIndex = Math.floor(index / maxClustersPerChunk);
+
+      if (!resultArray[chunkIndex]) {
+        resultArray[chunkIndex] = []; // start a new chunk
+      }
+
+      resultArray[chunkIndex].push(item);
+
+      return resultArray;
+      // tslint:disable-next-line:align
+    }, [] as ClusterResult[][]);
+
+    // for each chunk, calculate the move in distance and add them up
+    for (let i = 0; i < groupedClusters.length; i++) {
+      const clustersInGroup = groupedClusters[i];
+
+      console.log(
+        `calculating move in distance on ${clustersInGroup.length} clusters in chunk ${i + 1}...`
+      );
+
+      const t0_chunk = performance.now();
+      const chunkedMoveInTripResults = await getMoveInTrip(
+        osrm,
+        facilityLat,
+        facilityLng,
+        clustersInGroup
+      );
+      const t1_chunk = performance.now();
+      console.log(
+        `Running took ${t1_chunk - t0_chunk} milliseconds, move in distance: ${
+          chunkedMoveInTripResults.distance
+        }.`
+      );
+
+      totalMoveInDistance += chunkedMoveInTripResults.distance;
+    }
+  } else {
+    // not that many clusters, so don't bother chunking
+    console.log(`calculating move in distance on ${results.clusters.length} clusters...`);
+    const t0 = performance.now();
+    const moveInTripResults = await getMoveInTrip(osrm, facilityLat, facilityLng, results.clusters);
+    const t1 = performance.now();
+    console.log(
+      `Running took ${t1 - t0} milliseconds, move in distance: ${moveInTripResults.distance}.`
+    );
+
+    totalMoveInDistance = moveInTripResults.distance;
+  }
+
+  return totalMoveInDistance;
 };

--- a/transportation.ts
+++ b/transportation.ts
@@ -1,6 +1,7 @@
 import { getDistance } from 'geolib';
 import { ClusterResult, YearlyResult, YearlyTripResults } from 'models/types';
 import OSRM from 'osrm';
+import { performance } from 'perf_hooks';
 
 const MILES_PER_GALLON = 6;
 export const KM_TO_MILES = 0.621371;


### PR DESCRIPTION
- Use the latest @ucdavis/lca v1.6.0
- Update lca function
- In `processDistance` since supply curves do not require lca information, the values of construction and equipment are assigned 0. 
- Add unloading cost as part of feedstock cost
- Break a large number of clusters into chunks and calculate move-in in `processYear` 