### PR TITLE
use frcs npm v1.2.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -408,9 +408,9 @@
       }
     },
     "@ucdavis/frcs": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/@ucdavis/frcs/-/frcs-1.2.5.tgz",
-      "integrity": "sha512-idjraVHzn6vVmesFiQ9vclknEy2cCBPEh1BtdpYbD2wLlXYlGqEMjwYfI2pr7vZgwmKOYUJ9h9I5HG2hqWM/zw==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@ucdavis/frcs/-/frcs-1.2.6.tgz",
+      "integrity": "sha512-XTzyFh2RiWuwtXP063ZjHy6Vsjovfdfx4UgY9LMXSZcwYESv6D159+/mIcy3OnV8Ylm3IyK9yP2m+F7HYVBufw==",
       "requires": {
         "body-parser": "^1.18.3",
         "express": "^4.16.4",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@types/cors": "^2.8.12",
-    "@ucdavis/frcs": "^1.2.5",
+    "@ucdavis/frcs": "^1.2.6",
     "@ucdavis/lca": "^1.6.2",
     "@ucdavis/tea": "^1.4.1",
     "applicationinsights": "^2.1.9",

--- a/processYear.ts
+++ b/processYear.ts
@@ -403,9 +403,9 @@ const processCluster = async (
     const clusterFeedstock = frcsResult.residual.yieldPerAcre * cluster.area; // green tons
     const clusterCoproduct =
       (frcsResult.total.yieldPerAcre - frcsResult.residual.yieldPerAcre) * cluster.area; // green tons
-    // if (clusterFeedstock < 1) {
-    //   throw new Error(`Cluster biomass was: ${clusterFeedstock}, which is too low to use`);
-    // }
+    if (clusterFeedstock === 0) {
+      throw new Error(`Cluster feedstock was: ${clusterFeedstock}`);
+    }
 
     const routeOptions: OSRM.RouteOptions = {
       coordinates: [


### PR DESCRIPTION
- The new version of FRCS package fixed the bug that produced NaN when the weight of small trees or all trees are 0 
- Exclude the clusters having 0 biomass feedstock